### PR TITLE
Fix slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ File a ticket for suggestions or issues, submit a PR for updates to this wiki.
 
 ## Slack
 
-Sure. BeerJS has a Slack channel and there is a channel for #albuquerque. [Join](https://beerjs-slack-invite.herokuapp.com/) it here if you don't have enough Slack channels in your life.
+Sure. BeerJS has a Slack channel and there is a channel for #albuquerque. [Join](https://beers-slack-invite.herokuapp.com/) it here if you don't have enough Slack channels in your life.
 
 Oh and since we are talking about Slack, you can join the ABQWebgeeks Slack channel by filling out a simple form on our [website](http://www.abqwebgeeks.org).
 


### PR DESCRIPTION
The slack invitation link displays `Failed! token_revoked` when an email is submitted. Per https://github.com/beerjs/meta/issues/163, changing it to https://beers-slack-invite.herokuapp.com/, which I was able to use to join.